### PR TITLE
Use ed25519 secret key to sign session

### DIFF
--- a/src/notary.go
+++ b/src/notary.go
@@ -177,8 +177,9 @@ func preInit(w http.ResponseWriter, req *http.Request) {
 	blob := make([]byte, len(km.Blob))
 	copy(blob, km.Blob)
 	key := *km.PrivKey
+	masterKey := *km.MasterKey
 	km.Unlock()
-	out := s.PreInit(body, blob, key)
+	out := s.PreInit(body, blob, key, masterKey)
 	writeResponse(out, w)
 }
 

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -4,6 +4,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/x509"
@@ -602,8 +603,31 @@ func ECDSASign(key *ecdsa.PrivateKey, items ...[]byte) []byte {
 	return signature
 }
 
+func Ed25519Sign(key *ed25519.PrivateKey, items ...[]byte) []byte {
+	var concatAll []byte
+	for _, item := range items {
+		concatAll = append(concatAll, item...)
+	}
+	digest_to_be_signed := Sha256(concatAll)
+	return ed25519.Sign(*key, digest_to_be_signed)
+}
+
 func ECDSAPubkeyToPEM(key *ecdsa.PublicKey) []byte {
 	derBytes, err := x509.MarshalPKIXPublicKey(key)
+	if err != nil {
+		fmt.Println(err)
+		panic("x509.MarshalPKIXPublicKey")
+	}
+	block := &pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: derBytes,
+	}
+	pubKeyPEM := pem.EncodeToMemory(block)
+	return pubKeyPEM
+}
+
+func Ed25519PubkeyToPEM(key *ed25519.PublicKey) []byte {
+	derBytes, err := x509.MarshalPKIXPublicKey(*key)
 	if err != nil {
 		fmt.Println(err)
 		panic("x509.MarshalPKIXPublicKey")


### PR DESCRIPTION
As we know EdDSA signature is zkp friendly and considered cheap than ecdsa. So I was plan to replace with ecdsa format private key with EdDSA (ed25519). However, the ecdsa key is also used to "derive symmetric keys to encrypt the communication" therefore it cannot be dropped. Instead I only replaced master key with ed25519 key.

Also, originally there were two signature:
```
session signed by em key
em key, valid timestamp signed by master key
```

Simplifies to be only session signed by master key. I think it is same secure as the original (both are same secure when master key not leaked). So we can save one signature verification. Please comment if you think I'm wrong.